### PR TITLE
PyGithub v1.56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-__pycache__/
-.coverage
-.tox/
 *.egg-info/
+*.html
+.coverage
+.env
+.tox/
+__pycache__/
+build/
+dist/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=long_description,
     install_requires=[
         'markdown2==2.3.7',
-        'PyGithub==1.43.5',
+        'PyGithub==1.56',
         'PyYAML==5.3.1',
         'retrying==1.3.3',
         # This package has not been released to pypi since 2019,


### PR DESCRIPTION
I was getting this error. Fixed by upgrading PyGithub.

```
Searching for PyGithub==1.43.5
Reading https://pypi.org/simple/PyGithub/
/Users/adrian/src/ros-github-scripts/venv/lib/python3.10/site-packages/pkg_resources/__init__.py:123: PkgResourcesDeprecationWarning:  is an invalid version and will not be supported in a future release
  warnings.warn(
Downloading https://files.pythonhosted.org/packages/6d/13/6cf2d64c1de3a1d4892d69e4bea2039f920f373bc06b8962940ff5cde8bd/PyGithub-1.43.5.tar.gz#sha256=263102b43a83e2943900c1313109db7a00b3b78aeeae2c9137ba694982864872
Best match: PyGithub 1.43.5
Processing PyGithub-1.43.5.tar.gz
Writing /var/folders/ms/g4fyb1zs3cx5k4f3npp2qvfm0000gn/T/easy_install-i80zetu3/PyGithub-1.43.5/setup.cfg
Running PyGithub-1.43.5/setup.py -q bdist_egg --dist-dir /var/folders/ms/g4fyb1zs3cx5k4f3npp2qvfm0000gn/T/easy_install-i80zetu3/PyGithub-1.43.5/egg-dist-tmp-_3_i_enw
error: Setup script exited with error in PyGithub setup command: use_2to3 is invalid.
```