### PR TITLE
Add "jazzy" to the ROS_DISTRO_TO_UBUNTU_DISTRO list

### DIFF
--- a/ros_github_scripts/ci_for_pr.py
+++ b/ros_github_scripts/ci_for_pr.py
@@ -38,6 +38,7 @@ ROS_DISTRO_TO_UBUNTU_DISTRO = {
     'galactic': 'focal',
     'humble': 'jammy',
     'iron': 'jammy',
+    'jazzy': 'noble',
     'rolling': ''  # use default
 }
 


### PR DESCRIPTION
- Need to add "Jazzy" to be able to backport PRs with `ros2-ci-for-pr` script to it.