### PR TITLE
Fix return value of format_ci_details()

### DIFF
--- a/ros_github_scripts/ci_for_pr.py
+++ b/ros_github_scripts/ci_for_pr.py
@@ -224,12 +224,12 @@ def format_ci_details(
         details.append(f'Gist: {gist_url}')
     if branch_name:
         details.append(f'Branch: {branch_name}')
-    return details + [
+    return '\n'.join(details + [
         f'BUILD args: {extra_build_args}',
         f'TEST args: {extra_test_args}',
         f'ROS Distro: {target_release}',
         'Job: {}'.format(DEFAULT_JOB),
-    ]
+    ])
 
 
 def run_jenkins_build(


### PR DESCRIPTION
Woopsies.

I dropped the `'\n'.join()` and didn't notice it: https://github.com/ros-tooling/ros-github-scripts/pull/20/files#diff-a526c85ea7c27bc8523a4c9c5b5877dc90a2a87f38438d1682cafa486e587384L217