### PR TITLE
Use rolling branch for ros2.repos instead of master

### DIFF
--- a/ros_github_scripts/ci_for_pr.py
+++ b/ros_github_scripts/ci_for_pr.py
@@ -58,8 +58,6 @@ def panic(msg: str) -> None:
 def fetch_repos(target_release: str) -> dict:
     """Fetch the repos file for the specific release."""
     branch = target_release
-    if branch == 'rolling':
-        branch = 'master'
     repos_response = requests.get(REPOS_URL.format(branch))
 
     repos_text = repos_response.text


### PR DESCRIPTION
The branch of github.com/ros2/ros2 for the Rolling distro was changed from `master` to `rolling` some time ago (like most ROS 2 repos), so no need to use `master` for Rolling here.