### PR TITLE
Make sure package names don't contain invalid/unprintable chars

### DIFF
--- a/ros_github_scripts/ci_for_pr.py
+++ b/ros_github_scripts/ci_for_pr.py
@@ -367,8 +367,13 @@ def parse_args():
     # Create a group for these so that they are displayed below the 'change selection' group
     group = parser.add_argument_group(title='other options')
     group.add_argument('-h', '--help', action='help')
+    def printable_package_name(value):
+        if not value.isprintable():
+            raise argparse.ArgumentTypeError(
+                f'package name contains unprintable characters: {value!r}')
+        return value
     group.add_argument(
-        '-k', '--packages', type=str, nargs='+', default=None,
+        '-k', '--packages', type=printable_package_name, nargs='+', default=None,
         help='Space-separated list of packages to be built and tested.')
     group.add_argument(
         '-t', '--target', type=str, default=DEFAULT_TARGET,


### PR DESCRIPTION
This aims to detect my mistake here: https://github.com/ros2/rclpy/pull/1629#issuecomment-4148454453. I copied a package name from the GitHub PR files list, which included an invisible Unicode character (U+200E LEFT-TO-RIGHT MARK, UTF-8: E2 80 8E). This was very hard to figure out just by looking at the weird CI failure:

> Package '‎rclpy' specified with --packages-above-and-dependencies was not found

With this PR:

```console
$ ros-ci-for-pr -p ros2/rclpy#1629 -k ‎rclpy -t rolling -b -c
usage: ros-ci-for-pr [--branch BRANCH] [-p PULLS [PULLS ...] | -i] [-h] [-k PACKAGES [PACKAGES ...]] [-t TARGET] [-b] [-c] [--only-fixes-test] [--colcon-build-args COLCON_BUILD_ARGS]
                     [--colcon-test-args COLCON_TEST_ARGS] [--cmake-args CMAKE_ARGS]
ros-ci-for-pr: error: argument -k/--packages: package name contains unprintable characters: '\u200erclpy'
```