### PR TITLE
fix(pygithub): use Auth.Token API for newer PyGithub versions

### DIFF
--- a/ros_github_scripts/ci_for_pr.py
+++ b/ros_github_scripts/ci_for_pr.py
@@ -21,7 +21,7 @@ from typing import List
 from typing import Optional
 
 import github
-from github import Github, InputFileContent
+from github import Auth, Github, InputFileContent
 import requests
 import yaml
 
@@ -411,7 +411,7 @@ def main():
         github_access_token = os.environ.get('GITHUB_TOKEN')
     if not github_access_token:
         panic('Neither environment variable GITHUB_ACCESS_TOKEN nor GITHUB_TOKEN are set')
-    github_instance = Github(github_access_token)
+    github_instance = Github(auth=Auth.Token(github_access_token))
 
     branch_name = parsed.branch
     pull_texts = parsed.pulls


### PR DESCRIPTION
## Summary

The deprecated `Github(token)` positional argument (`login_or_token`) no longer authenticates in PyGithub >= 2.0 — it silently fails with a 401. Switch to the explicit `Github(auth=Auth.Token(token))` form.

## Key Changes

- `ros_github_scripts/ci_for_pr.py`: import `Auth` from `github`; replace `Github(github_access_token)` with `Github(auth=Auth.Token(github_access_token))`

## Did you use Generative AI?

Yes. Claude (claude-sonnet-4-6) via Claude Code was used to assist with implementing the changes in this PR.